### PR TITLE
src/ledger-ui: remove duplicate declaration G_ux

### DIFF
--- a/Dockerfile.build-all
+++ b/Dockerfile.build-all
@@ -1,0 +1,66 @@
+FROM ubuntu:16.04 AS base
+
+RUN apt-get update
+RUN apt-get install -y python3 python3-pil python3-setuptools python3-dev build-essential git wget tar libusb-1.0-0.dev libudev-dev gcc-multilib g++-multilib
+
+RUN mkdir -p /bolos-devenv
+WORKDIR /bolos-devenv
+ENV BOLOS_ENV=/bolos-devenv
+
+RUN echo "5a261cac18c62d8b7e8c70beba2004bd  gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2" > gcc.md5
+RUN wget https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2
+RUN md5sum -c gcc.md5
+RUN tar xjvf gcc-arm-none-eabi-5_3-2016q1-20160330-linux.tar.bz2
+
+RUN echo "87b88d620284d1f0573923e6f7cc89edccf11d19ebaec1cfb83b4f09ac5db09c  clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz" > clang.sha256
+RUN wget https://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+RUN shasum -a 256 -c clang.sha256
+RUN tar xvf clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+RUN ln -s clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-16.04 clang-arm-fropi
+
+
+FROM base AS builder
+
+RUN echo '#!/bin/bash\npython3 "$@"' > /usr/bin/python && \
+    chmod +x /usr/bin/python
+
+RUN git clone https://github.com/LedgerHQ/nanos-secure-sdk /nanos-secure-sdk
+RUN git clone https://github.com/LedgerHQ/nanox-secure-sdk /nanox-secure-sdk
+#RUN git clone https://github.com/LedgerHQ/blue-secure-sdk /blue-secure-sdk
+
+RUN mkdir -p /nanos
+RUN mkdir -p /nanox
+#RUN mkdir -p /blue
+
+ENV BOLOS_SDK=/nanos-secure-sdk
+WORKDIR /nanos-secure-sdk
+RUN git checkout nanos-og-1601
+WORKDIR /nanos
+COPY glyphs glyphs
+COPY src src
+COPY vendor vendor
+COPY Makefile Makefile
+COPY nanos_icon_hns.gif nanos_icon_hns.gif
+COPY nanox_icon_hns.gif nanox_icon_hns.gif
+RUN make
+
+ENV BOLOS_SDK=/nanox-secure-sdk
+WORKDIR /nanox
+COPY glyphs glyphs
+COPY src src
+COPY vendor vendor
+COPY Makefile Makefile
+COPY nanos_icon_hns.gif nanos_icon_hns.gif
+COPY nanox_icon_hns.gif nanox_icon_hns.gif
+RUN make
+
+#ENV BOLOS_SDK=/blue-secure-sdk
+#WORKDIR /blue-secure-sdk
+#WORKDIR /blue
+#COPY glyphs glyphs
+#COPY src src
+#COPY vendor vendor
+#COPY Makefile Makefile
+#COPY nanos_icon_hns.gif nanos_icon_hns.gif
+#COPY nanox_icon_hns.gif nanox_icon_hns.gif
+#RUN make

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,13 @@ docker:
 docker-load: docker
 	python -m ledgerblue.loadApp $(APP_LOAD_PARAMS)
 
+docker-build-all:
+	docker build -f Dockerfile.build-all -t ledger-app-hns-build-all .
+	docker run --name ledger-app-hns-build-all ledger-app-hns-build-all
+	docker cp ledger-app-hns-build-all:/nanos/bin/app.elf ./bin/hns-nanos.elf
+	docker cp ledger-app-hns-build-all:/nanox/bin/app.elf ./bin/hns-nanox.elf
+	#docker cp ledger-app-hns-build-all:/blue/bin/app.elf ./bin/hns-blue.elf
+
 MAKECMDGOALS := docker docker-load
 
 .PHONY: all load delete listvariants docker docker-load

--- a/README.md
+++ b/README.md
@@ -202,6 +202,39 @@ $ GIT_REF="nanos-1553" make docker-load
 
 <br/>
 
+## Build Apps Only (for emulator)
+
+To build both Nano S and Nano X apps using Docker:
+
+```bash
+$ make docker-build-all
+```
+
+This will run the build in a docker container and copy the final builds to
+`/bin/hns-nanos.elf` and `/bin/hns-nanox.elf`
+
+These two binaries can be executed inside the
+[Speculos emulator](https://github.com/LedgerHQ/speculos).
+For example, to run the built Nano S app in the emulator from docker:
+
+```
+docker run -v \
+  /path/to/ledger-app-hns/bin:/speculos/apps \
+  --publish 5900:5900 \
+  -it \
+  ledgerhq/speculos \
+  --display headless \
+  --vnc-port 5900 \
+  --vnc-password=xyz \
+  apps/hns-nanos.elf \
+  --model nanos
+```
+
+The command is explained in detail in the Speculos docs. Just note the path
+to the `/bin` directory and `model` argument. The emulated device can be
+accessed using a VNC client. On OSX, the `--vnc-password` argument is required
+and will be requested by the VNC client.
+
 ## Tests
 
 A suite of tests have been added to the [client library][tests]. They include

--- a/src/ledger-ui.c
+++ b/src/ledger-ui.c
@@ -394,8 +394,6 @@ ledger_ui_update(
 
 #else /* HAVE_UX_FLOW */
 
-ux_state_t G_ux;
-
 /**
  * Main menu screen for Ledger Nano X.
  */


### PR DESCRIPTION
Only error I got when building with `nanox-secure-sdk` -- still haven't tested in the emulator yet, but this fixed the build.

Note duplicate here:

https://github.com/handshake-org/ledger-app-hns/blob/8ff197ea02738168da2568078c598640721c41f4/src/ledger.c#L461-L466